### PR TITLE
auto: タイトルロゴ(TitleLogo)コンポーネントを追加

### DIFF
--- a/src/components/TitleLogo/TitleLogo.stories.tsx
+++ b/src/components/TitleLogo/TitleLogo.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { TitleLogo } from "./TitleLogo";
+
+const meta: Meta<typeof TitleLogo> = {
+  title: "App/TitleLogo",
+  component: TitleLogo,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/",
+        query: {},
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TitleLogo>;
+
+export const Default: Story = {
+  args: {
+    title: "Next16-AIDD",
+    backgroundColor: "#e5e7eb",
+    textColor: "#374151",
+    hoverTextColor: "#1f2937",
+    fontSize: "1.125rem",
+  },
+};
+
+export const Hover: Story = {
+  args: Default.args,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole("link", { name: "Next16-AIDD" });
+
+    await expect(link).toHaveStyle({ color: "rgb(55, 65, 81)" });
+    await userEvent.hover(link);
+    await expect(link).toHaveStyle({ color: "rgb(31, 41, 55)" });
+  },
+};

--- a/src/components/TitleLogo/TitleLogo.test.tsx
+++ b/src/components/TitleLogo/TitleLogo.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => {
+  type LinkMockProps = {
+    href: unknown;
+    children: ReactNode;
+  } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "children">;
+
+  return {
+    default: ({ href, children, ...props }: LinkMockProps) => (
+      <a href={String(href)} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+const mockUseSearchParams = vi.fn();
+
+vi.mock("next/navigation", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
+
+  return {
+    ...actual,
+    useSearchParams: () => mockUseSearchParams(),
+  };
+});
+
+import { TitleLogo } from "./TitleLogo";
+
+describe("TitleLogo", () => {
+  it("search 未指定・page 未指定のとき href が / になる", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+
+    render(<TitleLogo />);
+
+    expect(screen.getByRole("link", { name: "Next16-AIDD" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+  });
+
+  it("search 未指定・page=2 のとき href が / になる", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams({ page: "2" }));
+
+    render(<TitleLogo title="With Page Only" />);
+
+    expect(
+      screen.getByRole("link", { name: "With Page Only" }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("search=react・page 未指定のとき href が /?search=react になる", () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({ search: "react" }),
+    );
+
+    render(<TitleLogo title="With Search" />);
+
+    expect(screen.getByRole("link", { name: "With Search" })).toHaveAttribute(
+      "href",
+      "/?search=react",
+    );
+  });
+
+  it("search=react・page=2 のとき href が /?search=react&page=2 になる", () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({ search: "react", page: "2" }),
+    );
+
+    render(<TitleLogo title="With Search And Page" />);
+
+    expect(
+      screen.getByRole("link", { name: "With Search And Page" }),
+    ).toHaveAttribute("href", "/?search=react&page=2");
+  });
+
+  it("search=react・page が空/空白のみのとき href が /?search=react になる", () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({ search: "react", page: "" }),
+    );
+
+    render(<TitleLogo title="With Empty Page" />);
+
+    expect(
+      screen.getByRole("link", { name: "With Empty Page" }),
+    ).toHaveAttribute("href", "/?search=react");
+
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({ search: "react", page: "   " }),
+    );
+
+    render(<TitleLogo title="With Blank Page" />);
+
+    expect(
+      screen.getByRole("link", { name: "With Blank Page" }),
+    ).toHaveAttribute("href", "/?search=react");
+  });
+
+  it("デフォルトpropsの style が反映される", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+
+    render(<TitleLogo />);
+
+    const link = screen.getByRole("link", { name: "Next16-AIDD" });
+    expect(link).toHaveStyle({ backgroundColor: "rgb(229, 231, 235)" });
+    expect(link).toHaveStyle({ color: "rgb(55, 65, 81)" });
+    expect(link).toHaveStyle({ fontSize: "1.125rem" });
+  });
+
+  it("props 上書きで style が反映される", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+
+    render(
+      <TitleLogo
+        title="Override"
+        backgroundColor="#000000"
+        textColor="#ffffff"
+        hoverTextColor="#ff0000"
+        fontSize="2rem"
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Override" });
+    expect(link).toHaveStyle({ backgroundColor: "rgb(0, 0, 0)" });
+    expect(link).toHaveStyle({ color: "rgb(255, 255, 255)" });
+    expect(link).toHaveStyle({ fontSize: "2rem" });
+  });
+
+  it("hover/unhover で color が切り替わる", async () => {
+    const user = userEvent.setup();
+
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+
+    render(
+      <TitleLogo
+        title="Hover Target"
+        textColor="#000000"
+        hoverTextColor="#ff0000"
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Hover Target" });
+    expect(link).toHaveStyle({ color: "rgb(0, 0, 0)" });
+
+    await user.hover(link);
+    expect(link).toHaveStyle({ color: "rgb(255, 0, 0)" });
+
+    await user.unhover(link);
+    expect(link).toHaveStyle({ color: "rgb(0, 0, 0)" });
+  });
+
+  it("search=react・page=2（前後空白あり）で trim された href が生成される", () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({ search: "  hello  ", page: " 2 " }),
+    );
+
+    render(<TitleLogo title="With Params" />);
+
+    expect(screen.getByRole("link", { name: "With Params" })).toHaveAttribute(
+      "href",
+      "/?search=hello&page=2",
+    );
+  });
+
+  it("search が空/空白のみのとき href が常に / になる（page があっても付与しない）", () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({ search: "", page: "2" }),
+    );
+
+    render(<TitleLogo title="Empty Search" />);
+
+    expect(screen.getByRole("link", { name: "Empty Search" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({ search: "   ", page: "2" }),
+    );
+
+    render(<TitleLogo title="Blank Search" />);
+
+    expect(screen.getByRole("link", { name: "Blank Search" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+  });
+});

--- a/src/components/TitleLogo/TitleLogo.tsx
+++ b/src/components/TitleLogo/TitleLogo.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useMemo, useState } from "react";
+
+export type TitleLogoProps = {
+  title?: string;
+  backgroundColor?: string;
+  textColor?: string;
+  hoverTextColor?: string;
+  fontSize?: string;
+};
+
+const defaultProps = {
+  title: "Next16-AIDD",
+  backgroundColor: "#e5e7eb",
+  textColor: "#374151",
+  hoverTextColor: "#1f2937",
+  fontSize: "1.125rem",
+} as const;
+
+export const TitleLogo = ({
+  title = defaultProps.title,
+  backgroundColor = defaultProps.backgroundColor,
+  textColor = defaultProps.textColor,
+  hoverTextColor = defaultProps.hoverTextColor,
+  fontSize = defaultProps.fontSize,
+}: TitleLogoProps) => {
+  const searchParams = useSearchParams();
+  const [hovered, setHovered] = useState(false);
+
+  const href = useMemo(() => {
+    const search = searchParams.get("search")?.trim() ?? "";
+    const page = searchParams.get("page")?.trim() ?? "";
+
+    if (!search) return "/";
+
+    const params = new URLSearchParams({ search });
+    if (page) params.set("page", page);
+
+    return `/?${params.toString()}`;
+  }, [searchParams]);
+
+  return (
+    <Link
+      href={href}
+      className="inline-block w-fit text-lg font-bold"
+      style={{
+        backgroundColor,
+        color: hovered ? hoverTextColor : textColor,
+        fontSize,
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {title}
+    </Link>
+  );
+};


### PR DESCRIPTION
## 概要
TitleLogoコンポーネントを追加し、トップページへの戻り導線を提供します。

Issue: https://github.com/tomoyuki65/next16-aidd/issues/1

## 背景・目的
- GitHubリポジトリ検索アプリで、どのページからでもトップへ戻れる導線が必要なため
- 表示（タイトル/配色/サイズ）を利用箇所ごとにpropsで調整できるようにするため

## 実装内容
- `src/components/TitleLogo/TitleLogo.tsx` を追加（propsで `title/backgroundColor/textColor/hoverTextColor/fontSize` を指定可能）
- `useSearchParams()` から `search/page` を参照し、`search` が非空のときのみ `page` を引き継ぐ `href` を生成
- `App/TitleLogo` のStorybook（Default/Hover）と、href生成・props反映・hover挙動のUnit Testを追加

## テスト確認項目
- [ ] タイトル文言がpropsどおりに表示される
- [ ] `search/page` の組み合わせでリンクの `href` が仕様どおりになる
- [ ] hover/unhoverで文字色が `hoverTextColor` / `textColor` に切り替わる

## 影響範囲
- `src/components/TitleLogo/*` を新規追加

## 未対応・今後の課題
- なし