### PR TITLE
auto: Headerコンポーネントを追加

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Header } from "./Header";
+
+const meta: Meta<typeof Header> = {
+  title: "App/Header",
+  component: Header,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/",
+        query: {},
+      },
+    },
+  },
+  args: {
+    backgroundColorHex: undefined,
+    titleLogoProps: undefined,
+  },
+  argTypes: {
+    backgroundColorHex: {
+      control: { type: "color" },
+    },
+    titleLogoProps: {
+      control: "object",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {};
+
+export const CustomBackground: Story = {
+  args: {
+    backgroundColorHex: "#111827",
+    titleLogoProps: {
+      textColor: "#f9fafb",
+      hoverTextColor: "#ffffff",
+    },
+  },
+};
+
+const withFixedWidth =
+  (widthPx: number) => (StoryComponent: () => JSX.Element) => (
+    <div style={{ width: `${widthPx}px`, border: "1px dashed #d1d5db" }}>
+      <StoryComponent />
+    </div>
+  );
+
+export const Narrow: Story = {
+  decorators: [withFixedWidth(375)],
+};
+
+export const Wide: Story = {
+  decorators: [withFixedWidth(1024)],
+};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,29 @@
+import {
+  TitleLogo,
+  type TitleLogoProps,
+} from "@/components/TitleLogo/TitleLogo";
+
+export type HeaderProps = {
+  backgroundColorHex?: string;
+  titleLogoProps?: TitleLogoProps;
+};
+
+export const Header = ({ backgroundColorHex, titleLogoProps }: HeaderProps) => {
+  const mergedTitleLogoProps: TitleLogoProps = {
+    backgroundColor: "transparent",
+    ...titleLogoProps,
+  };
+
+  return (
+    <header
+      className="h-14 w-full bg-gray-200 px-4 sm:h-16 sm:px-6"
+      style={
+        backgroundColorHex ? { backgroundColor: backgroundColorHex } : undefined
+      }
+    >
+      <div className="mx-auto flex h-full w-full max-w-6xl items-center">
+        <TitleLogo {...mergedTitleLogoProps} />
+      </div>
+    </header>
+  );
+};


### PR DESCRIPTION
## 概要
共通Headerコンポーネントを追加し、TitleLogo表示と背景色の差し替えを提供する。

Issue: https://github.com/tomoyuki65/next16-aidd/issues/2

## 背景・目的
GitHubリポジトリ検索アプリで全ページ共通表示されるヘッダー（タイトル表示）を用意し、StorybookでUI仕様を確定するため。

## 実装内容
- `src/components/Header/Header.tsx` を追加し、Server Componentの `Header` を実装した
- `backgroundColorHex?: string` で背景色を `style.backgroundColor` で差し替え可能にした（未指定時は `bg-gray-200`）
- `titleLogoProps?: TitleLogoProps` で `TitleLogo` のpropsを `Header` 経由で制御できるようにした
- `src/components/Header/Header.stories.tsx` を追加し、`Default/CustomBackground/Narrow/Wide` を定義した

## テスト確認項目
- [ ] Headerが表示され、TitleLogoが描画される
- [ ] `CustomBackground` で背景色とTitleLogo文字色の差が確認できる
- [ ] `Narrow/Wide` でレイアウトが崩れない

## 影響範囲
- `src/components/Header/*` を追加
- Storybookに `App/Header` を追加

## 未対応・今後の課題
- なし
