### PR TITLE
auto: 共通Inputコンポーネントを追加

### DIFF
--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { FieldError } from "react-hook-form";
+
+import { Input } from "./Input";
+
+const requiredError: FieldError = {
+  type: "required",
+  message: "This field is required",
+};
+
+const meta: Meta<typeof Input> = {
+  title: "Common/Input",
+  component: Input,
+  decorators: [
+    (Story) => (
+      <div className="p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="w-80">
+      <Input {...args} />
+    </div>
+  ),
+  args: {
+    placeholder: "Search...",
+  },
+};
+
+export const TextSizeSm: Story = {
+  args: {
+    placeholder: "Small text",
+    textSize: "sm",
+  },
+};
+
+export const TextSizeLg: Story = {
+  args: {
+    placeholder: "Large text",
+    textSize: "lg",
+  },
+};
+
+export const TextColorHex: Story = {
+  args: {
+    placeholder: "Colored text",
+    textColorHex: "#0ea5e9",
+  },
+};
+
+export const TextColorHexRed: Story = {
+  args: {
+    placeholder: "Colored text (red)",
+    textColorHex: "#dc2626",
+    defaultValue: "Red text",
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    placeholder: "With error",
+    error: requiredError,
+    errorTextSize: "xs",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "Disabled",
+    disabled: true,
+  },
+};

--- a/src/components/common/Input/Input.test.tsx
+++ b/src/components/common/Input/Input.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { Input } from "./Input";
+
+describe("Input", () => {
+  it("placeholderが表示される", () => {
+    render(<Input placeholder="type here" />);
+    expect(screen.getByPlaceholderText("type here")).toBeInTheDocument();
+  });
+
+  it("textSize未指定時に text-base が付与される", () => {
+    render(<Input placeholder="x" />);
+    expect(screen.getByPlaceholderText("x")).toHaveClass("text-base");
+  });
+
+  it("デフォルト文字色が黒系（text-slate-900）になる", () => {
+    render(<Input placeholder="x" />);
+    expect(screen.getByPlaceholderText("x")).toHaveClass("text-slate-900");
+  });
+
+  it("textSize指定で文字サイズクラスが変わる", () => {
+    const { rerender } = render(<Input placeholder="x" textSize="sm" />);
+    expect(screen.getByPlaceholderText("x")).toHaveClass("text-sm");
+
+    rerender(<Input placeholder="x" textSize="lg" />);
+    expect(screen.getByPlaceholderText("x")).toHaveClass("text-lg");
+  });
+
+  it("textColorHex指定時に input.style.color が反映される", () => {
+    render(<Input placeholder="x" textColorHex="#111111" />);
+    const input = screen.getByPlaceholderText("x") as HTMLInputElement;
+    expect(input.style.color).toBe("rgb(17, 17, 17)");
+  });
+
+  it("error.message が表示され、 text-red-600 が付与される", () => {
+    render(
+      <Input
+        placeholder="x"
+        error={{ type: "manual", message: "Error message" }}
+      />,
+    );
+    const message = screen.getByText("Error message");
+    expect(message).toBeInTheDocument();
+    expect(message).toHaveClass("text-red-600");
+  });
+
+  it("errorTextSize未指定時に text-sm が付与される", () => {
+    render(
+      <Input
+        placeholder="x"
+        error={{ type: "manual", message: "Error message" }}
+      />,
+    );
+    expect(screen.getByText("Error message")).toHaveClass("text-sm");
+  });
+
+  it("errorTextSize=xs で text-xs が付与される", () => {
+    render(
+      <Input
+        placeholder="x"
+        error={{ type: "manual", message: "Error message" }}
+        errorTextSize="xs"
+      />,
+    );
+    expect(screen.getByText("Error message")).toHaveClass("text-xs");
+  });
+
+  it("react-hook-form の register() を渡して userEvent.type で値更新できる", async () => {
+    const Form = () => {
+      const { register } = useForm<{ field: string }>({
+        defaultValues: { field: "" },
+      });
+
+      return <Input placeholder="field" {...register("field")} />;
+    };
+
+    render(<Form />);
+
+    const input = screen.getByPlaceholderText("field");
+    await userEvent.type(input, "hello");
+    expect(input).toHaveValue("hello");
+  });
+});

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { forwardRef } from "react";
+import type { FieldError } from "react-hook-form";
+
+export type InputTextSize = "sm" | "base" | "lg";
+export type InputErrorTextSize = "xs" | "sm";
+
+export type InputProps = Omit<
+  React.ComponentPropsWithoutRef<"input">,
+  "size"
+> & {
+  textSize?: InputTextSize;
+  textColorHex?: string;
+  error?: FieldError;
+  errorTextSize?: InputErrorTextSize;
+};
+
+const inputTextSizeClasses: Record<InputTextSize, string> = {
+  sm: "text-sm",
+  base: "text-base",
+  lg: "text-lg",
+};
+
+const errorTextSizeClasses: Record<InputErrorTextSize, string> = {
+  xs: "text-xs",
+  sm: "text-sm",
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      className,
+      error,
+      errorTextSize,
+      style,
+      textColorHex,
+      textSize,
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedTextSizeClass = inputTextSizeClasses[textSize ?? "base"];
+    const resolvedErrorTextSizeClass =
+      errorTextSizeClasses[errorTextSize ?? "sm"];
+
+    const inputClassName = [
+      "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      resolvedTextSizeClass,
+      className,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    const resolvedStyle = textColorHex
+      ? { ...style, color: textColorHex }
+      : style;
+
+    return (
+      <div className="w-full">
+        <input
+          ref={ref}
+          className={inputClassName}
+          style={resolvedStyle}
+          {...props}
+        />
+        {error?.message ? (
+          <p
+            className={[
+              "mt-1",
+              resolvedErrorTextSizeClass,
+              "text-red-600",
+            ].join(" ")}
+          >
+            {error.message}
+          </p>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+Input.displayName = "Input";


### PR DESCRIPTION
## 概要
- Issue: https://github.com/tomoyuki65/next16-aidd/issues/3
- `react-hook-form` と連携できる共通 `Input` を追加

## 背景・目的
- フォーム等で再利用できる入力UIを提供するため

## 実装内容
- `src/components/common/Input/Input.tsx` を追加（`forwardRef`/`w-full`/基本スタイル）
- `textSize` で入力文字サイズを切替（`sm`/`base`/`lg`）
- `textColorHex` で入力文字色を指定可能
- `error.message` を下部に表示し、`text-red-600` を付与
- Storybook（`Common/Input`）とUnit testを追加

## テスト確認項目
- [ ] placeholderが表示される
- [ ] `textSize` 指定で文字サイズが切り替わる
- [ ] `textColorHex` 指定で文字色が反映される
- [ ] `error.message` が赤字で表示される
- [ ] `register()` を渡したときに入力値が更新できる

## 影響範囲
- `src/components/common/Input/*` の追加

## 未対応・今後の課題
- なし
