### PR TITLE
auto: 共通Buttonコンポーネントを追加

### DIFF
--- a/src/components/common/Button/Button.stories.tsx
+++ b/src/components/common/Button/Button.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Button } from "./Button";
+
+const meta: Meta<typeof Button> = {
+  title: "Common/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    children: "Button",
+  },
+  argTypes: {
+    bgClass: { control: "text" },
+    hoverBgClass: { control: "text" },
+    textColorClass: { control: "text" },
+    textSizeClass: { control: "text" },
+    paddingClass: { control: "text" },
+    type: { control: "select", options: ["button", "submit", "reset"] },
+    disabled: { control: "boolean" },
+    onClick: { action: "clicked" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: {
+    children: "Search",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "Disabled",
+    disabled: true,
+  },
+};
+
+export const CustomStyle: Story = {
+  args: {
+    children: "Custom",
+    bgClass: "bg-sky-600",
+    hoverBgClass: "hover:bg-sky-700",
+    textColorClass: "text-white",
+    textSizeClass: "text-sm",
+    paddingClass: "px-3 py-1",
+  },
+};
+
+export const Submit: Story = {
+  render: (args) => (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+      }}
+    >
+      <Button {...args} />
+    </form>
+  ),
+  args: {
+    children: "Submit",
+    type: "submit",
+  },
+};

--- a/src/components/common/Button/Button.test.tsx
+++ b/src/components/common/Button/Button.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Button } from "./Button";
+
+describe("Button", () => {
+  it("children（ボタンラベル）が表示される", () => {
+    render(<Button>Label</Button>);
+    expect(screen.getByRole("button", { name: "Label" })).toBeInTheDocument();
+  });
+
+  it("クリックで onClick が1回呼ばれる", () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Click</Button>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Click" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disabled のときクリックしても onClick が呼ばれない", () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        Disabled
+      </Button>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Disabled" }));
+    expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  it("type 属性（button/submit/reset）を指定できる", () => {
+    const { rerender } = render(<Button type="button">Type</Button>);
+    expect(screen.getByRole("button", { name: "Type" })).toHaveAttribute(
+      "type",
+      "button",
+    );
+
+    rerender(<Button type="submit">Type</Button>);
+    expect(screen.getByRole("button", { name: "Type" })).toHaveAttribute(
+      "type",
+      "submit",
+    );
+
+    rerender(<Button type="reset">Type</Button>);
+    expect(screen.getByRole("button", { name: "Type" })).toHaveAttribute(
+      "type",
+      "reset",
+    );
+  });
+
+  it("デフォルトのclass（bg-gray-700 / hover:bg-gray-800 / text-white）が付与される", () => {
+    render(<Button>Class</Button>);
+    const button = screen.getByRole("button", { name: "Class" });
+    expect(button).toHaveClass("bg-gray-700");
+    expect(button).toHaveClass("hover:bg-gray-800");
+    expect(button).toHaveClass("text-white");
+  });
+});

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { forwardRef } from "react";
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  bgClass?: string;
+  hoverBgClass?: string;
+  textColorClass?: string;
+  textSizeClass?: string;
+  paddingClass?: string;
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      bgClass = "bg-gray-700",
+      hoverBgClass = "hover:bg-gray-800",
+      textColorClass = "text-white",
+      textSizeClass = "text-base",
+      paddingClass = "px-6 py-2",
+      className,
+      type = "button",
+      ...props
+    },
+    ref,
+  ) => {
+    const buttonClassName = [
+      "inline-flex w-fit items-center justify-center rounded-md",
+      bgClass,
+      hoverBgClass,
+      textColorClass,
+      textSizeClass,
+      paddingClass,
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <button ref={ref} type={type} className={buttonClassName} {...props} />
+    );
+  },
+);
+
+Button.displayName = "Button";


### PR DESCRIPTION
## 概要
共通Buttonコンポーネントを追加し、StorybookでUI仕様とVitestで振る舞い契約を定義する。

Issue: https://github.com/tomoyuki65/next16-aidd/issues/4

## 背景・目的
画面ごとにボタン実装がばらつかないよう、共通利用できる最小単位のUIを標準化する。

## 実装内容
- `src/components/common/Button/Button.tsx` を追加（`forwardRef` / `type` / `disabled` / classカスタマイズprops）
- `src/components/common/Button/Button.stories.tsx` を追加（`Default` / `Disabled` / `CustomStyle` / `Submit`）
- `src/components/common/Button/Button.test.tsx` を追加（表示/クリック/disabled/type/デフォルトclass）

## テスト確認項目
- [ ] Defaultでボタンラベルが表示され、クリックでActionが発火する
- [ ] Disabledで操作不可になる
- [ ] CustomStyleでargsのclassが見た目に反映される
- [ ] Submitで `type="submit"` の利用例が確認できる

## 影響範囲
- `src/components/common/Button/*` の新規追加

## 未対応・今後の課題
- なし