### PR TITLE
auto: Searchコンポーネント追加とUI調整

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.75.0(react@19.2.4))
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -491,6 +494,11 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -916,6 +924,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/addon-a11y@10.3.6':
     resolution: {integrity: sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw==}
@@ -2726,6 +2737,11 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.75.0(react@19.2.4))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.75.0(react@19.2.4)
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -3008,6 +3024,8 @@ snapshots:
       picomatch: 4.0.4
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-a11y@10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:

--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Search } from "./Search";
+
+const meta: Meta<typeof Search> = {
+  title: "App/Search",
+  component: Search,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[32rem] max-w-[90vw] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    className: "flex w-full items-start gap-2",
+    inputWrapperClassName: undefined,
+    inputClassName: undefined,
+    inputTextColorHex: undefined,
+    buttonClassName: undefined,
+    buttonBgClass: undefined,
+    buttonHoverBgClass: undefined,
+    buttonTextColorClass: undefined,
+    buttonTextSizeClass: undefined,
+    buttonPaddingClass: undefined,
+    buttonBgColorHex: undefined,
+    buttonHoverBgColorHex: undefined,
+    buttonTextColorHex: undefined,
+    buttonLabel: undefined,
+    defaultQuery: "",
+  },
+  argTypes: {
+    onSearch: { action: "search" },
+    className: { control: "text" },
+    inputWrapperClassName: { control: "text" },
+    inputClassName: { control: "text" },
+    inputTextColorHex: { control: { type: "color" } },
+    buttonClassName: { control: "text" },
+    buttonBgClass: { control: "text" },
+    buttonHoverBgClass: { control: "text" },
+    buttonTextColorClass: { control: "text" },
+    buttonTextSizeClass: { control: "text" },
+    buttonPaddingClass: { control: "text" },
+    buttonBgColorHex: { control: { type: "color" } },
+    buttonHoverBgColorHex: { control: { type: "color" } },
+    buttonTextColorHex: { control: { type: "color" } },
+    buttonLabel: { control: "text" },
+    defaultQuery: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Search>;
+
+export const Default: Story = {
+  args: {
+    defaultQuery: "",
+  },
+};
+
+export const ValidFilled: Story = {
+  args: {
+    defaultQuery: "react-hook-form",
+  },
+};
+
+export const InvalidRegex: Story = {
+  args: {
+    defaultQuery: "invalid query",
+  },
+};
+
+export const InputTextColor: Story = {
+  args: {
+    defaultQuery: "react-hook-form",
+    inputTextColorHex: "#0284c7",
+  },
+};
+
+export const ButtonTextAndColor: Story = {
+  args: {
+    defaultQuery: "react-hook-form",
+    buttonLabel: "Search",
+    buttonTextColorClass: "text-amber-200",
+  },
+};
+
+export const ButtonBackground: Story = {
+  args: {
+    defaultQuery: "react-hook-form",
+    buttonBgColorHex: "#ef4444",
+    buttonHoverBgColorHex: "#dc2626",
+  },
+};
+
+const withFixedWidth =
+  (widthPx: number) => (StoryComponent: () => JSX.Element) => (
+    <div
+      style={{ width: `${widthPx}px` }}
+      className="rounded-md bg-slate-50 p-3"
+    >
+      <StoryComponent />
+    </div>
+  );
+
+export const Mobile: Story = {
+  decorators: [withFixedWidth(375)],
+  args: {
+    className: "grid w-full grid-cols-1 gap-2 sm:grid-cols-[1fr_auto]",
+    buttonClassName: "w-full sm:w-auto",
+  },
+};
+
+export const Desktop: Story = {
+  decorators: [withFixedWidth(1024)],
+  args: {
+    className: "grid w-full grid-cols-[1fr_auto] gap-2",
+  },
+};

--- a/src/components/Search/Search.test.tsx
+++ b/src/components/Search/Search.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Search } from "./Search";
+
+describe("Search", () => {
+  it("初期表示で input と button（name=検索）が表示される", () => {
+    render(<Search onSearch={() => {}} />);
+
+    expect(screen.getByRole("textbox", { name: "検索クエリ" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "検索" })).toBeVisible();
+  });
+
+  it("初期状態（空）で button が disabled である", () => {
+    render(<Search onSearch={() => {}} />);
+    expect(screen.getByRole("button", { name: "検索" })).toBeDisabled();
+  });
+
+  it("regex NG の入力で button が disabled である", async () => {
+    const user = userEvent.setup();
+    render(<Search onSearch={() => {}} />);
+
+    await user.type(screen.getByRole("textbox", { name: "検索クエリ" }), "a b");
+    expect(screen.getByRole("button", { name: "検索" })).toBeDisabled();
+  });
+
+  it("regex OK の入力で button が enabled である", async () => {
+    const user = userEvent.setup();
+    render(<Search onSearch={() => {}} />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "検索クエリ" }),
+      "react-hook-form",
+    );
+    expect(screen.getByRole("button", { name: "検索" })).toBeEnabled();
+  });
+
+  it("button click で onSearch が query 文字列で1回呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onSearch = vi.fn();
+    render(<Search onSearch={onSearch} />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "検索クエリ" }),
+      "react-hook-form",
+    );
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith("react-hook-form");
+  });
+
+  it("Enter submit で onSearch が query 文字列で1回呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onSearch = vi.fn();
+    render(<Search onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox", { name: "検索クエリ" });
+    await user.type(input, "react-hook-form{enter}");
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith("react-hook-form");
+  });
+
+  it("バリデーションNGの状態で submit しても onSearch が呼ばれない", async () => {
+    const user = userEvent.setup();
+    const onSearch = vi.fn();
+    render(<Search onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox", { name: "検索クエリ" });
+    await user.type(input, "a b{enter}");
+
+    expect(onSearch).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "../common/Button/Button";
+import { Input } from "../common/Input/Input";
+
+const searchSchema = z.object({
+  query: z
+    .string()
+    .min(1, { message: "入力は必須です" })
+    .regex(/^[A-Za-z0-9_.-]+$/, {
+      message: "半角英数字・_ . - のみ入力できます",
+    }),
+});
+
+type SearchFormValues = z.infer<typeof searchSchema>;
+
+export type SearchProps = {
+  onSearch: (query: string) => void;
+  className?: string;
+  inputWrapperClassName?: string;
+  inputClassName?: string;
+  inputTextColorHex?: string;
+  buttonClassName?: string;
+  buttonBgClass?: string;
+  buttonHoverBgClass?: string;
+  buttonTextColorClass?: string;
+  buttonTextSizeClass?: string;
+  buttonPaddingClass?: string;
+  buttonBgColorHex?: string;
+  buttonHoverBgColorHex?: string;
+  buttonTextColorHex?: string;
+  buttonLabel?: string;
+  defaultQuery?: string;
+};
+
+export const Search = ({
+  onSearch,
+  className = "flex w-full items-start gap-2",
+  inputWrapperClassName = "flex-1",
+  inputClassName,
+  inputTextColorHex,
+  buttonClassName,
+  buttonBgClass,
+  buttonHoverBgClass,
+  buttonTextColorClass,
+  buttonTextSizeClass,
+  buttonPaddingClass,
+  buttonBgColorHex,
+  buttonHoverBgColorHex,
+  buttonTextColorHex,
+  buttonLabel = "検索",
+  defaultQuery = "",
+}: SearchProps) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    trigger,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<SearchFormValues>({
+    resolver: zodResolver(searchSchema),
+    defaultValues: { query: defaultQuery },
+    mode: "onChange",
+  });
+
+  const prevDefaultQueryRef = useRef(defaultQuery);
+
+  useEffect(() => {
+    if (defaultQuery) {
+      void trigger("query");
+    }
+  }, [defaultQuery, trigger]);
+
+  useEffect(() => {
+    if (prevDefaultQueryRef.current === defaultQuery) {
+      return;
+    }
+
+    reset({ query: defaultQuery });
+    prevDefaultQueryRef.current = defaultQuery;
+
+    if (defaultQuery) {
+      void trigger("query");
+    }
+  }, [defaultQuery, reset, trigger]);
+
+  return (
+    <form
+      className={className}
+      onSubmit={handleSubmit(({ query }) => {
+        onSearch(query);
+      })}
+    >
+      <label className="sr-only" htmlFor="search-query">
+        検索クエリ
+      </label>
+      <div className={inputWrapperClassName}>
+        <Input
+          id="search-query"
+          placeholder="Repository..."
+          autoComplete="off"
+          error={errors.query}
+          className={inputClassName}
+          textColorHex={inputTextColorHex}
+          {...register("query")}
+        />
+      </div>
+      <Button
+        type="submit"
+        bgClass={buttonBgClass}
+        hoverBgClass={buttonHoverBgClass}
+        textColorClass={buttonTextColorClass}
+        textSizeClass={buttonTextSizeClass}
+        paddingClass={buttonPaddingClass}
+        bgColorHex={buttonBgColorHex}
+        hoverBgColorHex={buttonHoverBgColorHex}
+        textColorHex={buttonTextColorHex}
+        className={["h-[42px] shrink-0", buttonClassName]
+          .filter(Boolean)
+          .join(" ")}
+        disabled={!isValid || isSubmitting}
+      >
+        {buttonLabel}
+      </Button>
+    </form>
+  );
+};

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -8,6 +8,9 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   textColorClass?: string;
   textSizeClass?: string;
   paddingClass?: string;
+  bgColorHex?: string;
+  hoverBgColorHex?: string;
+  textColorHex?: string;
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -18,17 +21,31 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       textColorClass = "text-white",
       textSizeClass = "text-base",
       paddingClass = "px-6 py-2",
+      bgColorHex,
+      hoverBgColorHex,
+      textColorHex,
       className,
       type = "button",
+      style,
       ...props
     },
     ref,
   ) => {
+    const resolvedStyle =
+      bgColorHex || hoverBgColorHex || textColorHex
+        ? ({
+            ...style,
+            ...(bgColorHex ? { "--btn-bg": bgColorHex } : null),
+            ...(hoverBgColorHex ? { "--btn-bg-hover": hoverBgColorHex } : null),
+            ...(textColorHex ? { "--btn-text": textColorHex } : null),
+          } as React.CSSProperties)
+        : style;
+
     const buttonClassName = [
       "inline-flex w-fit items-center justify-center rounded-md",
-      bgClass,
-      hoverBgClass,
-      textColorClass,
+      bgColorHex ? "bg-[var(--btn-bg)]" : bgClass,
+      hoverBgColorHex ? "hover:bg-[var(--btn-bg-hover)]" : hoverBgClass,
+      textColorHex ? "text-[var(--btn-text)]" : textColorClass,
       textSizeClass,
       paddingClass,
       "disabled:cursor-not-allowed disabled:opacity-50",
@@ -38,7 +55,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       .join(" ");
 
     return (
-      <button ref={ref} type={type} className={buttonClassName} {...props} />
+      <button
+        ref={ref}
+        type={type}
+        className={buttonClassName}
+        style={resolvedStyle}
+        {...props}
+      />
     );
   },
 );

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -27,6 +27,11 @@ const errorTextSizeClasses: Record<InputErrorTextSize, string> = {
   sm: "text-sm",
 };
 
+const errorMinHeightClasses: Record<InputErrorTextSize, string> = {
+  xs: "min-h-4",
+  sm: "min-h-5",
+};
+
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
@@ -43,6 +48,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const resolvedTextSizeClass = inputTextSizeClasses[textSize ?? "base"];
     const resolvedErrorTextSizeClass =
       errorTextSizeClasses[errorTextSize ?? "sm"];
+    const resolvedErrorMinHeightClass =
+      errorMinHeightClasses[errorTextSize ?? "sm"];
 
     const inputClassName = [
       "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400",
@@ -65,17 +72,17 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           style={resolvedStyle}
           {...props}
         />
-        {error?.message ? (
-          <p
-            className={[
-              "mt-1",
-              resolvedErrorTextSizeClass,
-              "text-red-600",
-            ].join(" ")}
-          >
-            {error.message}
-          </p>
-        ) : null}
+        <p
+          className={[
+            "mt-1",
+            resolvedErrorTextSizeClass,
+            resolvedErrorMinHeightClass,
+            "text-red-600",
+            error?.message ? "visible" : "invisible",
+          ].join(" ")}
+        >
+          {error?.message ?? "\u00A0"}
+        </p>
       </div>
     );
   },


### PR DESCRIPTION
## 概要
Searchコンポーネントを追加し、Input/Buttonの表示揺れとスタイル上書きを改善する。
Issue: https://github.com/tomoyuki65/next16-aidd/issues/5

## 背景・目的
GitHubリポジトリ検索UIとして、入力・バリデーション・コールバック呼び出しに責務を限定した再利用可能なSearchコンポーネントが必要なため。

## 実装内容
- react-hook-form + zodResolver でSearchフォームを実装し、必須/正規表現バリデーションとsubmit時onSearch呼び出しを追加
- SearchのStorybook（Default/Valid/Invalid/Responsive + 色変更パターン）を追加
- SearchのUnit Test（disabled/callback/Enter submit）を追加
- Inputのエラーメッセージ領域を常時確保し、表示有無でレイアウトがズレないように調整
- ButtonにHex指定で背景色/hover背景色/文字色を上書きできるpropsを追加（Storybook Controls対応）
- 依存に @hookform/resolvers を追加

## テスト確認項目
- [ ] 空入力または不正入力のとき検索ボタンが無効になる
- [ ] 有効入力のとき検索ボタンが有効になり、クリック/Enterで検索イベントが発火する
- [ ] バリデーションエラー表示の有無でフォーム位置がズレない
- [ ] StorybookのButton背景色/文字色のカスタマイズが反映される

## 影響範囲
- Searchコンポーネントの追加
- 共通Input/Buttonコンポーネントの表示仕様

## 未対応・今後の課題
- なし
