### PR TITLE
auto: 共通Cardコンポーネントを追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+@source "../components/**/*.stories.tsx";
+@source "../../.storybook/**/*.{ts,tsx}";
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/src/components/common/Card/Card.stories.tsx
+++ b/src/components/common/Card/Card.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Card } from "./Card";
+
+const meta: Meta<typeof Card> = {
+  title: "Common/Card",
+  component: Card,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[360px] max-w-[calc(100vw-48px)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    repoName: "openai/codex",
+    ownerImageUrl: "https://avatars.githubusercontent.com/u/63446725?s=200&v=4",
+  },
+  argTypes: {
+    repoName: { control: "text" },
+    ownerImageUrl: { control: "text" },
+    repoNameTextSizeClassName: { control: "text" },
+    repoNameTextColorClassName: { control: "text" },
+    repoNameTextColorHex: { control: "color" },
+    paddingXClassName: { control: "text" },
+    borderClassName: { control: "text" },
+    shadowClassName: { control: "text" },
+    bgClassName: { control: "text" },
+    hoverBgClassName: { control: "text" },
+    bgColorHex: { control: "color" },
+    hoverBgColorHex: { control: "color" },
+    repoNameMaxLines: { control: "select", options: [undefined, 1, 2] },
+    minHeightClassName: { control: "text" },
+    className: { control: "text" },
+    onClick: { action: "clicked" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {};
+
+export const NoOwnerImage: Story = {
+  args: {
+    ownerImageUrl: undefined,
+  },
+};
+
+export const LongRepoName: Story = {
+  args: {
+    repoName:
+      "some-owner/some-very-very-very-very-very-very-very-long-repository-name-to-test-wrapping",
+  },
+};
+
+export const ClampedTwoLines: Story = {
+  args: {
+    repoName:
+      "some-owner/some-very-very-very-very-very-very-very-long-repository-name-to-test-wrapping",
+    repoNameMaxLines: 2,
+    minHeightClassName: "min-h-[88px]",
+  },
+};
+
+export const ListExampleFixedHeights: Story = {
+  render: (args) => (
+    <div className="flex w-full max-w-[420px] flex-col gap-3">
+      <Card {...args} repoName="owner/short" />
+      <Card
+        {...args}
+        repoName="owner/medium-repository-name"
+        ownerImageUrl={undefined}
+      />
+      <Card
+        {...args}
+        repoName="some-owner/some-very-very-very-very-very-very-very-long-repository-name-to-test-wrapping"
+      />
+      <Card {...args} repoName="owner/another-short" />
+      <Card
+        {...args}
+        repoName="owner/another-super-long-repository-name-to-ensure-we-trigger-the-second-line-and-then-some"
+      />
+    </div>
+  ),
+  args: {
+    repoNameMaxLines: 2,
+    minHeightClassName: "min-h-[88px]",
+    className: "w-full",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-[calc(100vw-48px)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const CustomTypography: Story = {
+  args: {
+    repoNameTextSizeClassName: "text-sm",
+    repoNameTextColorClassName: "text-sky-700",
+  },
+};
+
+export const CustomPaddingAndBg: Story = {
+  args: {
+    paddingXClassName: "px-3",
+    bgClassName: "bg-gray-900",
+    hoverBgClassName: "hover:bg-gray-800",
+    borderClassName: "border border-white/10",
+    shadowClassName: "shadow-none",
+    repoNameTextColorClassName: "text-white",
+  },
+};
+
+export const Responsive: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-[720px] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    className: "w-full max-w-[420px] md:max-w-[560px]",
+  },
+};

--- a/src/components/common/Card/Card.test.tsx
+++ b/src/components/common/Card/Card.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Card } from "./Card";
+
+describe("Card", () => {
+  it("カードが button として取得できる", () => {
+    render(
+      <Card repoName="owner/repo" ownerImageUrl="https://example.com/a" />,
+    );
+    expect(screen.getByRole("button", { name: "owner/repo" })).toBeVisible();
+  });
+
+  it("クリックで onClick が1回呼ばれる", () => {
+    const onClick = vi.fn();
+    render(
+      <Card
+        repoName="owner/repo"
+        ownerImageUrl="https://example.com/a"
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "owner/repo" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("ownerImageUrl 未指定時にフォールバックが表示される", () => {
+    render(<Card repoName="owner/repo" ownerImageUrl={undefined} />);
+    expect(
+      screen.getByRole("img", { name: "Owner image fallback" }),
+    ).toBeVisible();
+  });
+
+  it("画像読み込み失敗（error）時にフォールバックへ切り替わる", () => {
+    render(
+      <Card repoName="owner/repo" ownerImageUrl="https://example.com/a" />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "Owner avatar" }));
+    expect(
+      screen.getByRole("img", { name: "Owner image fallback" }),
+    ).toBeVisible();
+  });
+
+  it("repoNameMaxLines=2 のとき line-clamp-2 が付与される", () => {
+    render(
+      <Card
+        repoName="owner/repo"
+        ownerImageUrl="https://example.com/a"
+        repoNameMaxLines={2}
+      />,
+    );
+
+    expect(screen.getByText("owner/repo")).toHaveClass("line-clamp-2");
+  });
+});

--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+
+export type CardProps = {
+  repoName: string;
+  ownerImageUrl?: string;
+  onClick?: () => void;
+  className?: string;
+  borderClassName?: string;
+  shadowClassName?: string;
+  bgClassName?: string;
+  hoverBgClassName?: string;
+  bgColorHex?: string;
+  hoverBgColorHex?: string;
+  paddingXClassName?: string;
+  repoNameTextSizeClassName?: string;
+  repoNameTextColorClassName?: string;
+  repoNameTextColorHex?: string;
+  repoNameMaxLines?: 1 | 2;
+  minHeightClassName?: string;
+};
+
+export const Card = ({
+  repoName,
+  ownerImageUrl,
+  onClick,
+  className,
+  borderClassName = "border border-gray-200",
+  shadowClassName = "shadow-sm",
+  bgClassName = "bg-white",
+  hoverBgClassName = "hover:bg-gray-50",
+  bgColorHex,
+  hoverBgColorHex,
+  paddingXClassName = "px-6",
+  repoNameTextSizeClassName = "text-lg",
+  repoNameTextColorClassName = "text-slate-900",
+  repoNameTextColorHex,
+  repoNameMaxLines,
+  minHeightClassName,
+}: CardProps) => {
+  const [isOwnerImageFailed, setIsOwnerImageFailed] = useState(false);
+
+  const shouldShowOwnerImage = Boolean(ownerImageUrl) && !isOwnerImageFailed;
+
+  const resolvedStyle =
+    bgColorHex || hoverBgColorHex || repoNameTextColorHex
+      ? ({
+          ...(bgColorHex ? { "--card-bg": bgColorHex } : null),
+          ...(hoverBgColorHex ? { "--card-bg-hover": hoverBgColorHex } : null),
+          ...(repoNameTextColorHex
+            ? { "--card-repo-name-color": repoNameTextColorHex }
+            : null),
+        } as React.CSSProperties)
+      : undefined;
+
+  const rootClassName = [
+    "flex w-fit items-center gap-4 rounded-2xl",
+    borderClassName,
+    shadowClassName,
+    "py-4",
+    paddingXClassName,
+    bgColorHex ? "bg-[var(--card-bg)]" : bgClassName,
+    hoverBgColorHex ? "hover:bg-[var(--card-bg-hover)]" : hoverBgClassName,
+    "transition-colors",
+    "text-left",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300",
+    minHeightClassName,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const lineClampClassName =
+    repoNameMaxLines === 1
+      ? "line-clamp-1"
+      : repoNameMaxLines === 2
+        ? "line-clamp-2"
+        : undefined;
+
+  const repoNameClassName = [
+    repoNameTextSizeClassName,
+    repoNameTextColorHex
+      ? "text-[var(--card-repo-name-color)]"
+      : repoNameTextColorClassName,
+    lineClampClassName,
+    lineClampClassName ? "break-words" : "whitespace-normal break-words",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type="button"
+      className={rootClassName}
+      onClick={onClick}
+      aria-label={repoName}
+      style={resolvedStyle}
+    >
+      <div className="h-10 w-10 shrink-0">
+        {shouldShowOwnerImage ? (
+          // biome-ignore lint/performance/noImgElement: next/image のremote設定に依存しないため、まずは img で扱う
+          <img
+            src={ownerImageUrl}
+            alt="Owner avatar"
+            className="h-10 w-10 rounded-full object-cover"
+            onError={() => {
+              setIsOwnerImageFailed(true);
+            }}
+          />
+        ) : (
+          <div
+            role="img"
+            aria-label="Owner image fallback"
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-500"
+          >
+            icon
+          </div>
+        )}
+      </div>
+
+      <span className={repoNameClassName}>{repoName}</span>
+    </button>
+  );
+};


### PR DESCRIPTION
## 概要
- Issue: https://github.com/tomoyuki65/next16-aidd/issues/6
- 検索結果で再利用できる共通UIとしてクリック可能な `Card` コンポーネントを追加

## 背景・目的
- 検索結果一覧で「オーナーアイコン + リポジトリ名」を一貫した見た目/振る舞いで表示したい
- StorybookをUI仕様書、テストを振る舞い契約として先に固定する

## 実装内容
- `src/components/common/Card/Card.tsx` を追加（クリック対応・画像フォールバック・見た目/タイポグラフィ/背景の調整Props・2行クランプ等）
- `src/components/common/Card/Card.stories.tsx` を追加（各状態 + 固定高さ/2行クランプのリスト例）
- `src/components/common/Card/Card.test.tsx` を追加（クリック/フォールバック/line-clamp の挙動を検証）
- `src/app/globals.css` に `@source` を追加し、Story内のクラスもTailwind生成対象に含める

## テスト確認項目
- [ ] Cardがリポジトリ名で表示されクリックできる
- [ ] ownerImageUrl 未指定/読み込み失敗時にフォールバック（icon）になる
- [ ] repoNameMaxLines=2 指定時に2行で省略され、カード高さが揃う指定（minHeightClassName）でリスト表示が破綻しない

## 影響範囲
- `src/components/common/Card/*`（新規追加）
- `src/app/globals.css`（Tailwindのスキャン対象追加）

## 未対応・今後の課題
- なし