### PR TITLE
auto: 共通ページネーションコンポーネントを追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 
+@source "../**/*.{ts,tsx}";
 @source "../components/**/*.stories.tsx";
 @source "../../.storybook/**/*.{ts,tsx}";
 

--- a/src/components/common/Pagination/Pagination.stories.tsx
+++ b/src/components/common/Pagination/Pagination.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+
+import { Pagination } from "./Pagination";
+
+const meta: Meta<typeof Pagination> = {
+  title: "Common/Pagination",
+  component: Pagination,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    page: 1,
+    totalPages: 12,
+  },
+  argTypes: {
+    page: { control: { type: "number", min: 1, step: 1 } },
+    totalPages: { control: { type: "number", min: 1, step: 1 } },
+    className: { control: "text" },
+    onPageChange: { action: "pageChanged" },
+    buttonClassNames: { control: "object" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Pagination>;
+
+export const FirstPage: Story = {
+  args: {
+    page: 1,
+    totalPages: 12,
+  },
+};
+
+export const MiddlePage: Story = {
+  args: {
+    page: 6,
+    totalPages: 12,
+  },
+};
+
+export const LastPage: Story = {
+  args: {
+    page: 12,
+    totalPages: 12,
+  },
+};
+
+export const FewPagesNoEllipsis: Story = {
+  args: {
+    page: 3,
+    totalPages: 5,
+  },
+};
+
+export const Interactive: Story = {
+  render: (args) => {
+    const [page, setPage] = useState(args.page);
+
+    return (
+      <Pagination
+        {...args}
+        page={page}
+        onPageChange={(nextPage) => {
+          args.onPageChange?.(nextPage);
+          setPage(nextPage);
+        }}
+      />
+    );
+  },
+  args: {
+    page: 6,
+    totalPages: 12,
+  },
+};
+
+export const CustomButtonStyles: Story = {
+  args: {
+    page: 6,
+    totalPages: 12,
+    buttonClassNames: {
+      textSizeClass: "text-xs",
+      paddingClass: "px-2 py-1",
+      bgColorHex: "#0284c7",
+      hoverBgColorHex: "#0369a1",
+      textColorHex: "#ffffff",
+      activeBgColorHex: "#0c4a6e",
+      activeHoverBgColorHex: "#082f49",
+      activeTextColorHex: "#ffffff",
+    },
+  },
+};

--- a/src/components/common/Pagination/Pagination.test.tsx
+++ b/src/components/common/Pagination/Pagination.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Pagination } from "./Pagination";
+
+describe("Pagination", () => {
+  it("page=1 のとき '<<' が disabled になる", () => {
+    render(<Pagination page={1} totalPages={12} onPageChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "<<" })).toBeDisabled();
+  });
+
+  it("page=totalPages のとき '>>' が disabled になる", () => {
+    render(<Pagination page={12} totalPages={12} onPageChange={() => {}} />);
+    expect(screen.getByRole("button", { name: ">>" })).toBeDisabled();
+  });
+
+  it("数字ボタンのクリックで onPageChange(nextPage) が呼ばれる", () => {
+    const onPageChange = vi.fn();
+    render(<Pagination page={1} totalPages={12} onPageChange={onPageChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "3" }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it("'<<' と '>>' のクリックで onPageChange が最小/最大ページで呼ばれる（境界では呼ばれない）", () => {
+    const onPageChange = vi.fn();
+    const { rerender } = render(
+      <Pagination page={6} totalPages={12} onPageChange={onPageChange} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "<<" }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+
+    fireEvent.click(screen.getByRole("button", { name: ">>" }));
+    expect(onPageChange).toHaveBeenCalledWith(12);
+
+    onPageChange.mockClear();
+    rerender(
+      <Pagination page={1} totalPages={12} onPageChange={onPageChange} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "<<" }));
+    expect(onPageChange).toHaveBeenCalledTimes(0);
+
+    onPageChange.mockClear();
+    rerender(
+      <Pagination page={12} totalPages={12} onPageChange={onPageChange} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: ">>" }));
+    expect(onPageChange).toHaveBeenCalledTimes(0);
+  });
+
+  it("ページ番号の並びが先頭/中央/末尾で '…' を含む", () => {
+    const { rerender } = render(
+      <Pagination page={1} totalPages={12} onPageChange={() => {}} />,
+    );
+    expect(screen.getByText("…")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
+
+    rerender(<Pagination page={6} totalPages={12} onPageChange={() => {}} />);
+    expect(screen.getAllByText("…")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "6" })).toBeInTheDocument();
+
+    rerender(<Pagination page={12} totalPages={12} onPageChange={() => {}} />);
+    expect(screen.getByText("…")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "8" })).toBeInTheDocument();
+  });
+
+  it("選択中のページは aria-current=page になり disabled になる", () => {
+    render(<Pagination page={6} totalPages={12} onPageChange={() => {}} />);
+    const current = screen.getByRole("button", { name: "6" });
+    expect(current).toHaveAttribute("aria-current", "page");
+    expect(current).toBeDisabled();
+  });
+
+  it("buttonClassNames でボタンのclassを上書きできる", () => {
+    render(
+      <Pagination
+        page={6}
+        totalPages={12}
+        onPageChange={() => {}}
+        buttonClassNames={{
+          textSizeClass: "text-xs",
+          paddingClass: "px-2 py-1",
+          hoverBgClass: "hover:bg-sky-700",
+          bgClass: "bg-sky-600",
+          textColorClass: "text-white",
+          activeBgClass: "bg-sky-900",
+        }}
+      />,
+    );
+
+    const normal = screen.getByRole("button", { name: "5" });
+    expect(normal).toHaveClass("text-xs");
+    expect(normal).toHaveClass("px-2");
+    expect(normal).toHaveClass("py-1");
+    expect(normal).toHaveClass("bg-sky-600");
+    expect(normal).toHaveClass("hover:bg-sky-700");
+    expect(normal).toHaveClass("text-white");
+
+    const active = screen.getByRole("button", { name: "6" });
+    expect(active).toHaveClass("bg-sky-900");
+  });
+
+  it("クリックでページが切り替わると表示（可変ウィンドウ）が再計算される", async () => {
+    const onPageChange = vi.fn();
+
+    const Controlled = () => {
+      const [page, setPage] = useState(6);
+      return (
+        <Pagination
+          page={page}
+          totalPages={12}
+          onPageChange={(nextPage) => {
+            onPageChange(nextPage);
+            setPage(nextPage);
+          }}
+        />
+      );
+    };
+
+    render(<Controlled />);
+
+    // page=6 では中央ウィンドウ（… 2個 + 5,6,7）が表示される
+    expect(screen.getAllByText("…")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "6" })).toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "12" }));
+    expect(onPageChange).toHaveBeenCalledWith(12);
+
+    // page=12 に切り替わると末尾ウィンドウへ再計算される
+    expect(screen.getByRole("button", { name: "12" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "8" })).toBeInTheDocument();
+  });
+});

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { buildPaginationItems } from "../../../lib/pagination/buildPaginationItems";
+
+import { Button } from "../Button/Button";
+
+type ButtonClassNames = {
+  bgClass?: string;
+  hoverBgClass?: string;
+  textColorClass?: string;
+  textSizeClass?: string;
+  paddingClass?: string;
+  bgColorHex?: string;
+  hoverBgColorHex?: string;
+  textColorHex?: string;
+  activeBgClass?: string;
+  activeHoverBgClass?: string;
+  activeTextColorClass?: string;
+  activeTextSizeClass?: string;
+  activePaddingClass?: string;
+  activeBgColorHex?: string;
+  activeHoverBgColorHex?: string;
+  activeTextColorHex?: string;
+  disabledClass?: string;
+};
+
+export type PaginationProps = {
+  page: number;
+  totalPages: number;
+  onPageChange: (nextPage: number) => void;
+  className?: string;
+  buttonClassNames?: ButtonClassNames;
+};
+
+export const Pagination = ({
+  page,
+  totalPages,
+  onPageChange,
+  className,
+  buttonClassNames,
+}: PaginationProps) => {
+  const currentPage = Math.min(Math.max(1, page), totalPages);
+
+  const items = buildPaginationItems({ page: currentPage, totalPages });
+
+  const normalButtonStyles = {
+    bgClass: buttonClassNames?.bgClass ?? "bg-gray-200",
+    hoverBgClass: buttonClassNames?.hoverBgClass ?? "hover:bg-gray-300",
+    textColorClass: buttonClassNames?.textColorClass ?? "text-slate-900",
+    textSizeClass: buttonClassNames?.textSizeClass ?? "text-sm",
+    paddingClass: buttonClassNames?.paddingClass ?? "px-3 py-1",
+    bgColorHex: buttonClassNames?.bgColorHex,
+    hoverBgColorHex: buttonClassNames?.hoverBgColorHex,
+    textColorHex: buttonClassNames?.textColorHex,
+  };
+
+  const activeButtonStyles = {
+    bgClass: buttonClassNames?.activeBgClass ?? "bg-gray-700",
+    hoverBgClass: buttonClassNames?.activeHoverBgClass ?? "hover:bg-gray-800",
+    textColorClass: buttonClassNames?.activeTextColorClass ?? "text-white",
+    textSizeClass:
+      buttonClassNames?.activeTextSizeClass ?? normalButtonStyles.textSizeClass,
+    paddingClass:
+      buttonClassNames?.activePaddingClass ?? normalButtonStyles.paddingClass,
+    bgColorHex:
+      buttonClassNames?.activeBgColorHex ?? normalButtonStyles.bgColorHex,
+    hoverBgColorHex:
+      buttonClassNames?.activeHoverBgColorHex ??
+      normalButtonStyles.hoverBgColorHex,
+    textColorHex:
+      buttonClassNames?.activeTextColorHex ?? normalButtonStyles.textColorHex,
+  };
+
+  const extraButtonClassName = buttonClassNames?.disabledClass;
+
+  const handleFirst = () => {
+    if (currentPage <= 1) return;
+    onPageChange(1);
+  };
+
+  const handleLast = () => {
+    if (currentPage >= totalPages) return;
+    onPageChange(totalPages);
+  };
+
+  return (
+    <nav aria-label="Pagination" className={className}>
+      <ul className="flex items-center gap-1">
+        <li>
+          <Button
+            {...normalButtonStyles}
+            className={extraButtonClassName}
+            onClick={handleFirst}
+            disabled={currentPage <= 1}
+          >
+            {"<<"}
+          </Button>
+        </li>
+
+        {items.map((item, index) => {
+          if (item === "…") {
+            const prev = items[index - 1];
+            const next = items[index + 1];
+            const ellipsisKey = `ellipsis-${String(prev)}-${String(next)}`;
+
+            return (
+              <li key={ellipsisKey}>
+                <span
+                  className="px-2 text-sm text-slate-500"
+                  aria-hidden="true"
+                >
+                  …
+                </span>
+              </li>
+            );
+          }
+
+          const isCurrent = item === currentPage;
+          return (
+            <li key={item}>
+              <Button
+                {...(isCurrent ? activeButtonStyles : normalButtonStyles)}
+                className={extraButtonClassName}
+                onClick={() => {
+                  if (isCurrent) return;
+                  onPageChange(item);
+                }}
+                aria-current={isCurrent ? "page" : undefined}
+                disabled={isCurrent}
+              >
+                {item}
+              </Button>
+            </li>
+          );
+        })}
+
+        <li>
+          <Button
+            {...normalButtonStyles}
+            className={extraButtonClassName}
+            onClick={handleLast}
+            disabled={currentPage >= totalPages}
+          >
+            {">>"}
+          </Button>
+        </li>
+      </ul>
+    </nav>
+  );
+};

--- a/src/components/common/Pagination/index.ts
+++ b/src/components/common/Pagination/index.ts
@@ -1,0 +1,2 @@
+export type { PaginationProps } from "./Pagination";
+export { Pagination } from "./Pagination";

--- a/src/lib/pagination/buildPaginationItems.test.ts
+++ b/src/lib/pagination/buildPaginationItems.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPaginationItems } from "./buildPaginationItems";
+
+describe("buildPaginationItems", () => {
+  it("totalPages<=0 のとき空配列を返す", () => {
+    expect(buildPaginationItems({ page: 1, totalPages: 0 })).toEqual([]);
+  });
+
+  it("totalPages<=7 のとき全ページを返す", () => {
+    expect(buildPaginationItems({ page: 3, totalPages: 5 })).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+
+  it("先頭付近（page<=4）は 1..5 + '…' + last を返す", () => {
+    expect(buildPaginationItems({ page: 1, totalPages: 12 })).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      "…",
+      12,
+    ]);
+    expect(buildPaginationItems({ page: 4, totalPages: 12 })).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      "…",
+      12,
+    ]);
+  });
+
+  it("中央は 1 + '…' + (page-1,page,page+1) + '…' + last を返す", () => {
+    expect(buildPaginationItems({ page: 6, totalPages: 12 })).toEqual([
+      1,
+      "…",
+      5,
+      6,
+      7,
+      "…",
+      12,
+    ]);
+  });
+
+  it("末尾付近（page>=totalPages-3）は 1 + '…' + last-4..last を返す", () => {
+    expect(buildPaginationItems({ page: 12, totalPages: 12 })).toEqual([
+      1,
+      "…",
+      8,
+      9,
+      10,
+      11,
+      12,
+    ]);
+    expect(buildPaginationItems({ page: 9, totalPages: 12 })).toEqual([
+      1,
+      "…",
+      8,
+      9,
+      10,
+      11,
+      12,
+    ]);
+  });
+
+  it("page が範囲外でも 1..totalPages にクランプされる", () => {
+    expect(buildPaginationItems({ page: -1, totalPages: 12 })).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      "…",
+      12,
+    ]);
+    expect(buildPaginationItems({ page: 999, totalPages: 12 })).toEqual([
+      1,
+      "…",
+      8,
+      9,
+      10,
+      11,
+      12,
+    ]);
+  });
+});

--- a/src/lib/pagination/buildPaginationItems.ts
+++ b/src/lib/pagination/buildPaginationItems.ts
@@ -1,0 +1,49 @@
+export type PaginationItem = number | "…";
+
+type BuildPaginationItemsArgs = {
+  page: number;
+  totalPages: number;
+};
+
+export const buildPaginationItems = ({
+  page,
+  totalPages,
+}: BuildPaginationItemsArgs): PaginationItem[] => {
+  if (totalPages <= 0) return [];
+
+  const currentPage = Math.min(Math.max(1, page), totalPages);
+
+  // Small counts: show all pages.
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  // Near the start: show first 5 pages, ellipsis, last.
+  if (currentPage <= 4) {
+    return [1, 2, 3, 4, 5, "…", totalPages];
+  }
+
+  // Near the end: show first, ellipsis, last 5 pages.
+  if (currentPage >= totalPages - 3) {
+    return [
+      1,
+      "…",
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+      totalPages,
+    ];
+  }
+
+  // Middle: show first, ellipsis, window around current, ellipsis, last.
+  return [
+    1,
+    "…",
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    "…",
+    totalPages,
+  ];
+};


### PR DESCRIPTION
## 概要
共通ページネーションコンポーネントを追加し、Storybook/ユニットテストで仕様を固定します。
Issue: https://github.com/tomoyuki65/next16-aidd/issues/7

## 背景・目的
検索結果一覧などでページ切り替えUIが必要なため、`page/totalPages/onPageChange` を渡すだけで再利用できる共通コンポーネントとして整備します。

## 実装内容
- `Pagination` コンポーネント（`nav` + `aria-current` + disabled制御）を追加
- 可変ウィンドウ（`…`）表示用の純粋関数 `buildPaginationItems` を追加
- Storybookに `FirstPage/MiddlePage/LastPage/FewPagesNoEllipsis/Interactive/CustomButtonStyles` を追加
- Tailwindの `@source` を追加し、Storybook上で必要なユーティリティが生成されるよう調整

## テスト確認項目
- [ ] `page=1` のとき `<<` がdisabledになる
- [ ] `page=totalPages` のとき `>>` がdisabledになる
- [ ] 数字/端ボタンのクリックで `onPageChange(nextPage)` が正しい引数で呼ばれる
- [ ] 先頭/中央/末尾で `…` を含むページ番号表示になる
- [ ] 選択中のページが `aria-current=page` になり disabled になる
- [ ] `buildPaginationItems` が想定の配列を返す（先頭/中央/末尾/クランプ）

## 影響範囲
- `src/components/common/Pagination/*` を新規追加
- `src/lib/pagination/*` を新規追加
- `src/app/globals.css` に `@source` を追加

## 未対応・今後の課題
- なし