### PR TITLE
auto: TopPage(検索/一覧/ページング)を追加

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,14 @@
 import type { Preview } from "@storybook/nextjs-vite";
 import "@/app/globals.css";
 import { initialize, mswLoader } from "msw-storybook-addon";
+import { githubHandlers } from "@/lib/msw/handlers/github";
+import { sampleHandlers } from "@/lib/msw/handlers/sample";
 
 // mswの初期化
-initialize();
+initialize({ onUnhandledRequest: "warn" }, [
+  ...sampleHandlers,
+  ...githubHandlers,
+]);
 
 const preview: Preview = {
   // mswの設定追加

--- a/src/components/TopPage/TopPage.stories.tsx
+++ b/src/components/TopPage/TopPage.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { delay, HttpResponse, http } from "msw";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
+
+import { endpoints } from "@/lib/api/endpoints";
+
+import { TopPage } from "./TopPage";
+
+const meta: Meta<typeof TopPage> = {
+  title: "App/TopPage",
+  component: TopPage,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/",
+        query: {},
+      },
+    },
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-zinc-50 font-sans">
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <Story />
+        </SWRConfig>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TopPage>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        query: { search: "react", page: "1" },
+      },
+    },
+    msw: {
+      handlers: [
+        http.get(endpoints.github.searchRepositories, async () => {
+          await delay("infinite");
+          return HttpResponse.json({ total_count: 0, items: [] });
+        }),
+      ],
+    },
+  },
+};
+
+export const ErrorState: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        query: { search: "react", page: "1" },
+      },
+    },
+    msw: {
+      handlers: [
+        http.get(endpoints.github.searchRepositories, () => {
+          return HttpResponse.json({ message: "Mock error" }, { status: 500 });
+        }),
+      ],
+    },
+  },
+};
+
+export const Results: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        query: { search: "react", page: "1" },
+      },
+    },
+  },
+};
+
+const withFixedWidth =
+  (widthPx: number) => (StoryComponent: () => ReactElement) => (
+    <div style={{ width: `${widthPx}px` }}>
+      <StoryComponent />
+    </div>
+  );
+
+export const Mobile: Story = {
+  decorators: [withFixedWidth(375)],
+  parameters: {
+    nextjs: {
+      navigation: {
+        query: { search: "react", page: "1" },
+      },
+    },
+  },
+};
+
+export const Desktop: Story = {
+  decorators: [withFixedWidth(1024)],
+  parameters: {
+    nextjs: {
+      navigation: {
+        query: { search: "react", page: "1" },
+      },
+    },
+  },
+};

--- a/src/components/TopPage/TopPage.test.tsx
+++ b/src/components/TopPage/TopPage.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { TopPage } from "./TopPage";
+
+let mockedSearchParams = new URLSearchParams();
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => {
+  return {
+    useRouter: () => ({
+      push: pushMock,
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      back: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+    useSearchParams: () => mockedSearchParams,
+  };
+});
+
+describe("TopPage", () => {
+  it("URLに search/page がある場合、初期表示で検索結果（5件）とページネーションが表示される", async () => {
+    mockedSearchParams = new URLSearchParams({ search: "react", page: "1" });
+
+    render(<TopPage />);
+
+    const list = await screen.findByRole("list", { name: "検索結果" });
+    const items = within(list).getAllByRole("listitem");
+    expect(items).toHaveLength(5);
+
+    expect(
+      within(items[0] ?? document.body).getByRole("button", {
+        name: "test/react-repo-1",
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole("navigation", { name: "Pagination" }),
+    ).toBeVisible();
+  });
+
+  it("ページ切り替えでURLが更新され、表示（5件）が切り替わる", async () => {
+    mockedSearchParams = new URLSearchParams({ search: "react", page: "1" });
+    pushMock.mockClear();
+
+    const user = userEvent.setup();
+    render(<TopPage />);
+
+    await screen.findByRole("button", { name: "test/react-repo-1" });
+    await user.click(screen.getByRole("button", { name: "2" }));
+
+    expect(pushMock).toHaveBeenCalledWith("/?search=react&page=2");
+    await screen.findByRole("button", { name: "test/react-repo-6" });
+  });
+
+  it("APIエラー時にエラー表示が出る", async () => {
+    mockedSearchParams = new URLSearchParams({ search: "error", page: "1" });
+
+    render(<TopPage />);
+
+    expect(await screen.findByText("検索に失敗しました")).toBeInTheDocument();
+  });
+});

--- a/src/components/TopPage/TopPage.tsx
+++ b/src/components/TopPage/TopPage.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import useSWR from "swr";
+import { Card } from "@/components/common/Card/Card";
+import { Pagination } from "@/components/common/Pagination/Pagination";
+import { Search } from "@/components/Search/Search";
+import { searchRepositories } from "@/lib/api/github";
+import type { GitHubRepository } from "@/types/github";
+
+const UI_PAGE_SIZE = 5;
+const API_PAGE_SIZE = 100;
+const MAX_TOTAL_COUNT = 1000;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const parsePositiveInt = (value: string | null) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (!Number.isInteger(parsed)) return undefined;
+  if (parsed <= 0) return undefined;
+  return parsed;
+};
+
+const buildTopPageHref = (search: string, page: number) => {
+  const trimmed = search.trim();
+  if (!trimmed) return "/";
+
+  const params = new URLSearchParams({ search: trimmed, page: String(page) });
+  return `/?${params.toString()}`;
+};
+
+const buildRepoDetailHref = (
+  repoFullName: string,
+  search: string,
+  page: number,
+) => {
+  const [owner, repo] = repoFullName.split("/");
+  if (!owner || !repo) return buildTopPageHref(search, page);
+
+  const params = new URLSearchParams();
+  const trimmed = search.trim();
+  if (trimmed) params.set("search", trimmed);
+  params.set("page", String(page));
+
+  return `/repos/${owner}/${repo}?${params.toString()}`;
+};
+
+export const TopPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const rawSearch = searchParams.get("search")?.trim() ?? "";
+  const hasPageParam = searchParams.has("page");
+  // In Storybook, the iframe URL can contain a generic `search` query parameter
+  // for Storybook itself. Avoid treating that as the app's query unless `page`
+  // is also present (which we always set when we update the URL).
+  const urlSearch = hasPageParam ? rawSearch : "";
+  const urlPageRaw = parsePositiveInt(searchParams.get("page")) ?? 1;
+
+  const [query, setQuery] = useState(urlSearch);
+  const [page, setPage] = useState(urlPageRaw);
+
+  useEffect(() => {
+    setQuery(urlSearch);
+    setPage(urlPageRaw);
+  }, [urlSearch, urlPageRaw]);
+
+  const { apiPage, sliceStart } = useMemo(() => {
+    const zeroBasedOffset = (page - 1) * UI_PAGE_SIZE;
+    const apiPageComputed = Math.floor(zeroBasedOffset / API_PAGE_SIZE) + 1;
+    const sliceStartComputed = zeroBasedOffset % API_PAGE_SIZE;
+    return { apiPage: apiPageComputed, sliceStart: sliceStartComputed };
+  }, [page]);
+
+  const swrKey = query ? (["githubSearch", query, apiPage] as const) : null;
+
+  const { data, error, isLoading } = useSWR(
+    swrKey,
+    async ([, q, apiPageValue]) => {
+      return await searchRepositories({
+        query: q,
+        perPage: API_PAGE_SIZE,
+        page: apiPageValue,
+      });
+    },
+  );
+
+  const totalCount = data?.total_count ?? 0;
+  const clampedTotalCount = Math.min(totalCount, MAX_TOTAL_COUNT);
+  const totalPages = query ? Math.ceil(clampedTotalCount / UI_PAGE_SIZE) : 0;
+
+  const resolvedPage = totalPages > 0 ? clamp(page, 1, totalPages) : page;
+
+  const visibleItems: GitHubRepository[] = useMemo(() => {
+    if (!data?.items) return [];
+    if (resolvedPage !== page) return [];
+    return data.items.slice(sliceStart, sliceStart + UI_PAGE_SIZE);
+  }, [data?.items, page, resolvedPage, sliceStart]);
+
+  const showResults = Boolean(query) && !isLoading && !error;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-50 font-sans">
+      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-6 sm:px-6">
+        <Search
+          defaultQuery={query}
+          onSearch={(nextQuery) => {
+            setQuery(nextQuery);
+            setPage(1);
+            router.push(buildTopPageHref(nextQuery, 1));
+          }}
+        />
+
+        {query ? (
+          <div className="flex flex-col gap-4">
+            {isLoading ? (
+              <output className="text-slate-600" aria-live="polite">
+                Loading...
+              </output>
+            ) : error ? (
+              <div role="alert" className="text-red-600">
+                検索に失敗しました
+              </div>
+            ) : showResults && clampedTotalCount === 0 ? (
+              <div className="text-slate-600">結果がありません</div>
+            ) : showResults ? (
+              <>
+                <ul className="flex flex-col gap-3" aria-label="検索結果">
+                  {visibleItems.map((item) => (
+                    <li key={item.id}>
+                      <Card
+                        repoName={item.full_name}
+                        ownerImageUrl={item.owner.avatar_url}
+                        className="w-full"
+                        repoNameMaxLines={2}
+                        minHeightClassName="min-h-[88px]"
+                        onClick={() => {
+                          router.push(
+                            buildRepoDetailHref(item.full_name, query, page),
+                          );
+                        }}
+                      />
+                    </li>
+                  ))}
+                </ul>
+
+                {totalPages > 1 ? (
+                  <div className="flex justify-end pt-2">
+                    <Pagination
+                      page={resolvedPage}
+                      totalPages={totalPages}
+                      onPageChange={(nextPage) => {
+                        setPage(nextPage);
+                        router.push(buildTopPageHref(query, nextPage));
+                      }}
+                    />
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </main>
+    </div>
+  );
+};

--- a/src/components/common/Pagination/Pagination.test.tsx
+++ b/src/components/common/Pagination/Pagination.test.tsx
@@ -51,19 +51,28 @@ describe("Pagination", () => {
     expect(onPageChange).toHaveBeenCalledTimes(0);
   });
 
-  it("ページ番号の並びが先頭/中央/末尾で '…' を含む", () => {
+  it("ページ番号の並びが先頭/中央/末尾で適切に省略される（<< >> と重複する 1/last を出さない）", () => {
     const { rerender } = render(
       <Pagination page={1} totalPages={12} onPageChange={() => {}} />,
     );
     expect(screen.getByText("…")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "12" }),
+    ).not.toBeInTheDocument();
 
     rerender(<Pagination page={6} totalPages={12} onPageChange={() => {}} />);
     expect(screen.getAllByText("…")).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: "1" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "12" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "6" })).toBeInTheDocument();
 
     rerender(<Pagination page={12} totalPages={12} onPageChange={() => {}} />);
     expect(screen.getByText("…")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "1" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "12" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "8" })).toBeInTheDocument();
   });
 
@@ -127,7 +136,7 @@ describe("Pagination", () => {
     expect(screen.getByRole("button", { name: "6" })).toBeDisabled();
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "12" }));
+    await user.click(screen.getByRole("button", { name: ">>" }));
     expect(onPageChange).toHaveBeenCalledWith(12);
 
     // page=12 に切り替わると末尾ウィンドウへ再計算される

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -41,7 +41,15 @@ export const Pagination = ({
 }: PaginationProps) => {
   const currentPage = Math.min(Math.max(1, page), totalPages);
 
-  const items = buildPaginationItems({ page: currentPage, totalPages });
+  const baseItems = buildPaginationItems({ page: currentPage, totalPages });
+  const items =
+    totalPages <= 7
+      ? baseItems
+      : baseItems.filter((item) => {
+          if (item === 1) return currentPage === 1;
+          if (item === totalPages) return currentPage === totalPages;
+          return true;
+        });
 
   const normalButtonStyles = {
     bgClass: buttonClassNames?.bgClass ?? "bg-gray-200",

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -1,0 +1,7 @@
+export const endpoints = {
+  github: {
+    searchRepositories: "https://api.github.com/search/repositories",
+    repositoryDetail: (owner: string, repo: string) =>
+      `https://api.github.com/repos/${owner}/${repo}`,
+  },
+} as const;

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -1,0 +1,36 @@
+import type { GitHubSearchRepositoriesResponse } from "@/types/github";
+import { endpoints } from "./endpoints";
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+export type SearchRepositoriesParams = {
+  query: string;
+  perPage?: number;
+  page?: number;
+  signal?: AbortSignal;
+};
+
+export const searchRepositories = async ({
+  query,
+  perPage = 100,
+  page = 1,
+  signal,
+}: SearchRepositoriesParams): Promise<GitHubSearchRepositoriesResponse> => {
+  const clampedPerPage = clamp(perPage, 1, 100);
+  const clampedPage = clamp(page, 1, 10);
+
+  const url = new URL(endpoints.github.searchRepositories);
+  url.searchParams.set("q", query);
+  url.searchParams.set("per_page", String(clampedPerPage));
+  url.searchParams.set("page", String(clampedPage));
+
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub Search API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as GitHubSearchRepositoriesResponse;
+};

--- a/src/lib/msw/handlers/github.ts
+++ b/src/lib/msw/handlers/github.ts
@@ -1,28 +1,44 @@
 import { HttpResponse, http, type RequestHandler } from "msw";
+import { endpoints } from "@/lib/api/endpoints";
 
 // search repositories
 const searchRepositoriesHandler = http.get(
-  "https://api.github.com/search/repositories",
+  endpoints.github.searchRepositories,
   ({ request }) => {
     const url = new URL(request.url);
-    const q = url.searchParams.get("q");
+    const q = url.searchParams.get("q") ?? "";
+    const perPageRaw = Number(url.searchParams.get("per_page") ?? "30");
+    const pageRaw = Number(url.searchParams.get("page") ?? "1");
+
+    if (q === "error") {
+      return HttpResponse.json({ message: "Mock error" }, { status: 500 });
+    }
+
+    const total_count = q === "empty" ? 0 : 250;
+    const perPage = Math.min(100, Math.max(1, perPageRaw || 30));
+    const page = Math.min(10, Math.max(1, pageRaw || 1));
+
+    const start = (page - 1) * perPage;
+    const end = Math.min(total_count, start + perPage);
+    const items =
+      total_count <= 0
+        ? []
+        : Array.from({ length: Math.max(0, end - start) }, (_, index) => {
+            const ordinal = start + index + 1;
+            return {
+              id: ordinal,
+              name: `${q}-repo-${ordinal}`,
+              full_name: `test/${q}-repo-${ordinal}`,
+              owner: {
+                login: "test",
+                avatar_url: "https://github.com/test.png",
+              },
+            };
+          });
 
     return HttpResponse.json({
-      total_count: 2,
-      items: [
-        {
-          id: 1,
-          name: `${q}-repo-1`,
-          full_name: `test/${q}-repo-1`,
-          owner: { login: "test" },
-        },
-        {
-          id: 2,
-          name: `${q}-repo-2`,
-          full_name: `test/${q}-repo-2`,
-          owner: { login: "test" },
-        },
-      ],
+      total_count,
+      items,
     });
   },
 );

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,16 @@
+export type GitHubOwner = {
+  login: string;
+  avatar_url?: string;
+};
+
+export type GitHubRepository = {
+  id: number;
+  name: string;
+  full_name: string;
+  owner: GitHubOwner;
+};
+
+export type GitHubSearchRepositoriesResponse = {
+  total_count: number;
+  items: GitHubRepository[];
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,13 +12,30 @@ const dirname =
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
 
+const alias = [
+  {
+    find: /^@\//,
+    replacement: `${path.join(dirname, "src")}/`,
+  },
+  {
+    find: "@",
+    replacement: path.join(dirname, "src"),
+  },
+] as const;
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
+  resolve: {
+    alias,
+  },
   test: {
     projects: [
       // ユニットテスト用（integration含む）
       {
         plugins: [react()],
+        resolve: {
+          alias,
+        },
         test: {
           name: "unit",
           environment: "jsdom",
@@ -35,6 +52,9 @@ export default defineConfig({
           // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
           storybookTest({ configDir: path.join(dirname, ".storybook") }),
         ],
+        resolve: {
+          alias,
+        },
         test: {
           name: "storybook",
           browser: {


### PR DESCRIPTION
## 概要
- Issue: https://github.com/tomoyuki65/next16-aidd/issues/8
- TopPage(検索/一覧/ページング)を追加

## 背景・目的
- URLクエリ（search/page）から検索状態を復元できるトップページを用意するため

## 実装内容
- `src/components/TopPage` を追加（Client Component、SWRでGitHub Search API連携、5件/ページの表示・ページング、URL更新）
- `src/lib/api/endpoints.ts` / `src/lib/api/github.ts` / `src/types/github.ts` を追加
- `src/lib/msw/handlers/github.ts` を更新（Search APIのper_page/page対応、成功/空/エラーの分岐）
- `.storybook/preview.ts` を更新（MSW初期化時にhandlersを常時注入）
- `src/components/common/Pagination/Pagination.tsx` を更新（`<<`/`>>` と重複する端の番号表示を調整）
- `vitest.config.ts` を更新（`@/` エイリアス解決）

## テスト確認項目
- [ ] `?search=<value>&page=<value>` があるとき、初期表示で検索結果とページネーションが表示される
- [ ] ページ操作で表示が切り替わり、URLが更新される
- [ ] APIエラー時に「検索に失敗しました」が表示される

## 影響範囲
- `src/components/TopPage/*`
- `.storybook/preview.ts`
- `src/components/common/Pagination/*`
- `src/lib/api/*` / `src/types/github.ts` / `src/lib/msw/handlers/github.ts` / `vitest.config.ts`

## 未対応・今後の課題
- なし
