### PR TITLE
auto: RepositoryDetailPageの詳細表示を追加

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/nextjs-vite";
 import "@/app/globals.css";
 import { initialize, mswLoader } from "msw-storybook-addon";
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from "storybook/viewport";
 import { githubHandlers } from "@/lib/msw/handlers/github";
 import { sampleHandlers } from "@/lib/msw/handlers/sample";
 
@@ -15,6 +16,12 @@ const preview: Preview = {
   loaders: [mswLoader],
 
   parameters: {
+    viewport: {
+      options: {
+        ...INITIAL_VIEWPORTS,
+        ...MINIMAL_VIEWPORTS,
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/src/components/RepositoryDetailPage/RepositoryDetailPage.stories.tsx
+++ b/src/components/RepositoryDetailPage/RepositoryDetailPage.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { delay, HttpResponse, http } from "msw";
+import { SWRConfig } from "swr";
+
+import { endpoints } from "@/lib/api/endpoints";
+
+import { RepositoryDetailPage } from "./RepositoryDetailPage";
+
+const meta: Meta<typeof RepositoryDetailPage> = {
+  title: "App/RepositoryDetailPage",
+  component: RepositoryDetailPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-zinc-50 font-sans">
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <Story />
+        </SWRConfig>
+      </div>
+    ),
+  ],
+  args: {
+    owner: "test",
+    repo: "hello-world",
+  },
+  argTypes: {
+    owner: { control: "text" },
+    repo: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RepositoryDetailPage>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(
+          endpoints.github.repositoryDetail("test", "hello-world"),
+          async () => {
+            await delay("infinite");
+            return HttpResponse.json({});
+          },
+        ),
+      ],
+    },
+  },
+};
+
+export const ErrorState: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(
+          endpoints.github.repositoryDetail("test", "hello-world"),
+          () => {
+            return HttpResponse.json(
+              { message: "Mock error" },
+              { status: 500 },
+            );
+          },
+        ),
+      ],
+    },
+  },
+};
+
+export const MobilIphone5: Story = {
+  globals: {
+    viewport: { value: "iphone5", isRotated: false },
+  },
+};
+
+export const MobilIphone14promax: Story = {
+  globals: {
+    viewport: { value: "iphone14promax", isRotated: false },
+  },
+};
+
+export const TabletIpad: Story = {
+  globals: {
+    viewport: { value: "ipad", isRotated: false },
+  },
+};
+
+export const Desktop: Story = {
+  globals: {
+    viewport: { value: "desktop", isRotated: false },
+  },
+};

--- a/src/components/RepositoryDetailPage/RepositoryDetailPage.test.tsx
+++ b/src/components/RepositoryDetailPage/RepositoryDetailPage.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { delay, HttpResponse, http } from "msw";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
+import { describe, expect, it } from "vitest";
+
+import { endpoints } from "@/lib/api/endpoints";
+import { server } from "@/lib/msw/setup/server";
+
+import { RepositoryDetailPage } from "./RepositoryDetailPage";
+
+const renderWithSWR = (ui: ReactElement) => {
+  return render(
+    <SWRConfig value={{ provider: () => new Map() }}>{ui}</SWRConfig>,
+  );
+};
+
+describe("RepositoryDetailPage", () => {
+  it("Successでリポジトリ名・言語・各種カウントが表示される", async () => {
+    renderWithSWR(<RepositoryDetailPage owner="test" repo="my-repo" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "test/my-repo" }),
+    ).toBeVisible();
+    expect(screen.getByText("Language: TypeScript")).toBeVisible();
+
+    expect(screen.getByText("Star数")).toBeVisible();
+    expect(screen.getByText("1,200")).toBeVisible();
+    expect(screen.getByText("Watcher数")).toBeVisible();
+    expect(screen.getByText("300")).toBeVisible();
+    expect(screen.getByText("Fork数")).toBeVisible();
+    expect(screen.getByText("150")).toBeVisible();
+    expect(screen.getByText("Issue数")).toBeVisible();
+    expect(screen.getByText("42")).toBeVisible();
+  });
+
+  it("Loading状態でローディング表示が見える", async () => {
+    server.use(
+      http.get(
+        endpoints.github.repositoryDetail("test", "loading"),
+        async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    renderWithSWR(<RepositoryDetailPage owner="test" repo="loading" />);
+    expect(screen.getByText("Loading...")).toBeVisible();
+  });
+
+  it("Error状態でエラー表示が見える", async () => {
+    server.use(
+      http.get(endpoints.github.repositoryDetail("test", "error"), () => {
+        return HttpResponse.json({ message: "Mock error" }, { status: 500 });
+      }),
+    );
+
+    renderWithSWR(<RepositoryDetailPage owner="test" repo="error" />);
+
+    expect(await screen.findByRole("alert")).toBeVisible();
+    expect(
+      screen.getByText("リポジトリ詳細の取得に失敗しました"),
+    ).toBeVisible();
+  });
+});

--- a/src/components/RepositoryDetailPage/RepositoryDetailPage.tsx
+++ b/src/components/RepositoryDetailPage/RepositoryDetailPage.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { fetchRepoDetail } from "@/lib/api/github";
+
+export type RepositoryDetailPageProps = {
+  owner: string;
+  repo: string;
+};
+
+const formatNumber = (value: number) => new Intl.NumberFormat().format(value);
+
+export const RepositoryDetailPage = ({
+  owner,
+  repo,
+}: RepositoryDetailPageProps) => {
+  const [isOwnerImageFailed, setIsOwnerImageFailed] = useState(false);
+
+  const swrKey = owner && repo ? (["repoDetail", owner, repo] as const) : null;
+
+  const { data, error, isLoading } = useSWR(swrKey, async ([, o, r]) => {
+    return await fetchRepoDetail({ owner: o, repo: r });
+  });
+
+  const pageClassName =
+    "flex w-full flex-1 flex-col items-center px-4 py-10 sm:px-6";
+
+  if (isLoading) {
+    return (
+      <div className={pageClassName}>
+        <output className="text-slate-600" aria-live="polite">
+          Loading...
+        </output>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={pageClassName}>
+        <div role="alert" className="text-red-600">
+          リポジトリ詳細の取得に失敗しました
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const shouldShowOwnerImage =
+    Boolean(data.owner.avatar_url) && !isOwnerImageFailed;
+
+  return (
+    <div className={pageClassName}>
+      <div className="w-full max-w-[44rem] rounded-3xl border border-slate-200 bg-white px-5 py-6 shadow-md sm:px-8 sm:py-8">
+        <div className="mx-auto w-full max-w-[38rem]">
+          <div className="grid gap-y-10 md:grid-cols-4 md:gap-x-10">
+            <header className="flex justify-center md:col-span-1 md:justify-self-center">
+              <div className="h-16 w-16 shrink-0">
+                {shouldShowOwnerImage ? (
+                  // biome-ignore lint/performance/noImgElement: next/image のremote設定に依存しないため
+                  <img
+                    src={data.owner.avatar_url}
+                    alt="Owner avatar"
+                    className="h-16 w-16 rounded-full object-cover"
+                    onError={() => {
+                      setIsOwnerImageFailed(true);
+                    }}
+                  />
+                ) : (
+                  <div
+                    role="img"
+                    aria-label="Owner image fallback"
+                    className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-200 text-sm font-semibold text-slate-500"
+                  >
+                    icon
+                  </div>
+                )}
+              </div>
+            </header>
+
+            <div className="min-w-0 text-center md:col-span-3 md:text-left">
+              <h1 className="break-words text-2xl font-semibold text-slate-900">
+                {data.full_name}
+              </h1>
+              <p className="mt-3 text-lg text-slate-700">
+                Language: {data.language ?? "—"}
+              </p>
+            </div>
+
+            <section className="md:col-span-4" aria-label="Repository stats">
+              <dl className="grid grid-cols-4 gap-x-3 gap-y-8 sm:gap-x-6 md:gap-x-10">
+                <div className="text-center">
+                  <dt className="whitespace-nowrap text-xs font-semibold leading-tight text-slate-900 sm:text-xl">
+                    Star数
+                  </dt>
+                  <dd className="mt-4 text-lg text-slate-700 sm:mt-5 sm:text-2xl">
+                    {formatNumber(data.stargazers_count)}
+                  </dd>
+                </div>
+                <div className="text-center">
+                  <dt className="whitespace-nowrap text-xs font-semibold leading-tight text-slate-900 sm:text-xl">
+                    Watcher数
+                  </dt>
+                  <dd className="mt-4 text-lg text-slate-700 sm:mt-5 sm:text-2xl">
+                    {formatNumber(data.watchers_count)}
+                  </dd>
+                </div>
+                <div className="text-center">
+                  <dt className="whitespace-nowrap text-xs font-semibold leading-tight text-slate-900 sm:text-xl">
+                    Fork数
+                  </dt>
+                  <dd className="mt-4 text-lg text-slate-700 sm:mt-5 sm:text-2xl">
+                    {formatNumber(data.forks_count)}
+                  </dd>
+                </div>
+                <div className="text-center">
+                  <dt className="whitespace-nowrap text-xs font-semibold leading-tight text-slate-900 sm:text-xl">
+                    Issue数
+                  </dt>
+                  <dd className="mt-4 text-lg text-slate-700 sm:mt-5 sm:text-2xl">
+                    {formatNumber(data.open_issues_count)}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -1,8 +1,49 @@
-import type { GitHubSearchRepositoriesResponse } from "@/types/github";
+import type {
+  GitHubRepositoryDetail,
+  GitHubSearchRepositoriesResponse,
+} from "@/types/github";
 import { endpoints } from "./endpoints";
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
+
+export type FetchRepoDetailParams = {
+  owner: string;
+  repo: string;
+  signal?: AbortSignal;
+};
+
+export const fetchRepoDetail = async ({
+  owner,
+  repo,
+  signal,
+}: FetchRepoDetailParams): Promise<GitHubRepositoryDetail> => {
+  const url = endpoints.github.repositoryDetail(owner, repo);
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub Repo API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const json = (await response.json()) as GitHubRepositoryDetail;
+
+  return {
+    id: json.id,
+    name: json.name,
+    full_name: json.full_name,
+    owner: {
+      login: json.owner.login,
+      avatar_url: json.owner.avatar_url,
+    },
+    language: json.language ?? null,
+    stargazers_count: json.stargazers_count,
+    watchers_count: json.watchers_count,
+    forks_count: json.forks_count,
+    open_issues_count: json.open_issues_count,
+    description: json.description ?? null,
+  };
+};
 
 export type SearchRepositoriesParams = {
   query: string;

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -10,6 +10,19 @@ export type GitHubRepository = {
   owner: GitHubOwner;
 };
 
+export type GitHubRepositoryDetail = {
+  id: number;
+  name: string;
+  full_name: string;
+  owner: GitHubOwner;
+  language: string | null;
+  stargazers_count: number;
+  watchers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+  description: string | null;
+};
+
 export type GitHubSearchRepositoriesResponse = {
   total_count: number;
   items: GitHubRepository[];


### PR DESCRIPTION
## 概要
Issue: https://github.com/tomoyuki65/next16-aidd/issues/10
RepositoryDetailPageでリポジトリ詳細（名前/言語/各種カウント）を表示できるようにします。

## 背景・目的
リポジトリ検索結果から選択したリポジトリの詳細情報を確認できるようにするため。
StorybookとVitestで状態（Success/Loading/Error）を確認できるようにします。

## 実装内容
- RepositoryDetailPage（Client Component + SWR）を追加し、Success/Loading/Errorを表示
- GitHub Repo Detail取得用の fetchRepoDetail と型 GitHubRepositoryDetail を追加
- StorybookにRepositoryDetailPageのstories（Default/Loading/Error/viewport切替）を追加
- VitestでSuccess/Loading/Errorの振る舞いテストを追加
- Storybookのviewport設定（preview parameters）を追加

## テスト確認項目
- [ ] owner/repo指定でリポジトリ名・言語・各数値が表示される
- [ ] Loading状態でLoading...が表示される
- [ ] Error状態でエラーメッセージが表示される
- [ ] Storybookの各viewportでレイアウトが崩れない

## 影響範囲
- src/components/RepositoryDetailPage 配下
- src/lib/api/github.ts
- src/types/github.ts
- .storybook/preview.ts

## 未対応・今後の課題
- なし
