### PR TITLE
auto: リポジトリ詳細画面ルートを追加

### DIFF
--- a/src/app/repository-detail/[owner]/[repo]/layout.tsx
+++ b/src/app/repository-detail/[owner]/[repo]/layout.tsx
@@ -1,0 +1,7 @@
+export default function RepositoryDetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/repository-detail/[owner]/[repo]/page.tsx
+++ b/src/app/repository-detail/[owner]/[repo]/page.tsx
@@ -1,0 +1,18 @@
+import { RepositoryDetailPage } from "@/components/RepositoryDetailPage/RepositoryDetailPage";
+
+type PageProps = {
+  params: Promise<{
+    owner: string;
+    repo: string;
+  }>;
+  searchParams?: {
+    search?: string;
+    page?: string;
+  };
+};
+
+export default async function RepositoryDetailRoutePage({ params }: PageProps) {
+  const { owner, repo } = await params;
+
+  return <RepositoryDetailPage owner={owner} repo={repo} />;
+}

--- a/src/components/TopPage/TopPage.tsx
+++ b/src/components/TopPage/TopPage.tsx
@@ -45,7 +45,7 @@ const buildRepoDetailHref = (
   if (trimmed) params.set("search", trimmed);
   params.set("page", String(page));
 
-  return `/repos/${owner}/${repo}?${params.toString()}`;
+  return `/repository-detail/${owner}/${repo}?${params.toString()}`;
 };
 
 export const TopPage = () => {

--- a/tests/integration/header-logo-query-preserve.test.tsx
+++ b/tests/integration/header-logo-query-preserve.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => {
+  type LinkMockProps = {
+    href: unknown;
+    children: ReactNode;
+  } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "children">;
+
+  return {
+    default: ({ href, children, ...props }: LinkMockProps) => (
+      <a href={String(href)} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+let mockedPathname = "/repository-detail/test/my-repo";
+let mockedSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => {
+  return {
+    usePathname: () => mockedPathname,
+    useSearchParams: () => mockedSearchParams,
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      back: vi.fn(),
+      prefetch: vi.fn(),
+      forward: vi.fn(),
+    }),
+  };
+});
+
+import { Header } from "@/components/Header/Header";
+
+describe("Header logo query preserve (integration)", () => {
+  it("search/page がある詳細画面で、ロゴリンクが /?search=...&page=... になる", () => {
+    mockedPathname = "/repository-detail/test/my-repo";
+    mockedSearchParams = new URLSearchParams({ search: "react", page: "2" });
+
+    render(<Header />);
+
+    expect(screen.getByRole("link", { name: "Next16-AIDD" })).toHaveAttribute(
+      "href",
+      "/?search=react&page=2",
+    );
+  });
+
+  it("search/page が無い詳細画面で、ロゴリンクが / になる", () => {
+    mockedPathname = "/repository-detail/test/my-repo";
+    mockedSearchParams = new URLSearchParams();
+
+    render(<Header />);
+
+    expect(screen.getByRole("link", { name: "Next16-AIDD" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+  });
+});


### PR DESCRIPTION
## 概要
Issue: https://github.com/tomoyuki65/next16-aidd/issues/11

App Router にリポジトリ詳細ルート（`/repository-detail/{owner}/{repo}`）を追加し、一覧→詳細の遷移導線を有効化しました。あわせて、詳細画面からヘッダーロゴでトップへ戻る際に `search`/`page` クエリが維持されることを integration テストで担保します。

## 背景・目的
- 一覧→詳細の導線を提供するため
- 一覧に戻った際に検索条件（`search`/`page`）を維持し、UXを損なわないため

## 実装内容
- `src/app/repository-detail/[owner]/[repo]/` を追加し、既存の `RepositoryDetailPage` を呼び出す
- 一覧の詳細リンクを `/repository-detail/{owner}/{repo}` へ変更する
- 詳細画面でロゴクリック時に `search`/`page` がトップへ引き継がれることを integration テストで追加する

## テスト確認項目
- [ ] 一覧から詳細へ遷移でき、詳細が表示される
- [ ] 詳細画面でロゴクリックするとトップへ戻り、`search`/`page` が付与される（存在する場合）

## 影響範囲
- リポジトリ詳細画面のルーティング追加
- 一覧から詳細への遷移URL変更（`/repository-detail/...`）

## 未対応・今後の課題
- なし