### PR TITLE
auto: GitHub検索のE2E（検索→詳細→戻る→キャッシュ）を追加

### DIFF
--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("トップページが表示される", async ({ page }) => {
-  await page.goto("http://localhost:3000");
+  await page.goto("/");
 
   await expect(page).toHaveTitle("Next16-AIDD");
 });

--- a/tests/e2e/mocks/github.ts
+++ b/tests/e2e/mocks/github.ts
@@ -1,0 +1,38 @@
+import type {
+  GitHubRepositoryDetail,
+  GitHubSearchRepositoriesResponse,
+} from "@/types/github";
+
+export const buildSearchRepositoriesResponse =
+  (): GitHubSearchRepositoriesResponse => {
+    return {
+      total_count: 1,
+      items: [
+        {
+          id: 101,
+          name: "next16-aidd",
+          full_name: "next16-ai/next16-aidd",
+          owner: {
+            login: "next16-ai",
+          },
+        },
+      ],
+    };
+  };
+
+export const buildRepoDetailResponse = (): GitHubRepositoryDetail => {
+  return {
+    id: 101,
+    name: "next16-aidd",
+    full_name: "next16-ai/next16-aidd",
+    owner: {
+      login: "next16-ai",
+    },
+    language: "TypeScript",
+    stargazers_count: 123,
+    watchers_count: 45,
+    forks_count: 6,
+    open_issues_count: 7,
+    description: "E2E mock repository detail",
+  };
+};

--- a/tests/e2e/search-flow.spec.ts
+++ b/tests/e2e/search-flow.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  buildRepoDetailResponse,
+  buildSearchRepositoriesResponse,
+} from "./mocks/github";
+
+test("GitHub検索のhappy-path（検索→詳細→戻る→キャッシュ）", async ({
+  page,
+}) => {
+  let searchCallCount = 0;
+  let repoDetailCallCount = 0;
+
+  await page.route("https://api.github.com/**", async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname === "/search/repositories") {
+      searchCallCount += 1;
+      await route.fulfill({
+        status: 200,
+        json: buildSearchRepositoriesResponse(),
+      });
+      return;
+    }
+
+    const repoDetailMatch = url.pathname.match(/^\/repos\/([^/]+)\/([^/]+)$/);
+    if (repoDetailMatch) {
+      repoDetailCallCount += 1;
+      await route.fulfill({ status: 200, json: buildRepoDetailResponse() });
+      return;
+    }
+
+    await route.abort();
+  });
+
+  await page.goto("/");
+
+  await page.getByLabel("検索クエリ").fill("next16-ai");
+  await page.getByRole("button", { name: "検索" }).click();
+
+  await expect(page.getByRole("list", { name: "検索結果" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "next16-ai/next16-aidd" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "next16-ai/next16-aidd" }).click();
+
+  await expect(page).toHaveURL(/\/repository-detail\/next16-ai\/next16-aidd/);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "next16-ai/next16-aidd" }),
+  ).toBeVisible();
+
+  await expect(page.getByText("Language:")).toBeVisible();
+  await expect(page.getByText("Star数")).toBeVisible();
+  await expect(page.getByText("Watcher数")).toBeVisible();
+  await expect(page.getByText("Fork数")).toBeVisible();
+  await expect(page.getByText("Issue数")).toBeVisible();
+
+  await page.getByRole("link", { name: "Next16-AIDD" }).click();
+
+  await expect(page).toHaveURL("/?search=next16-ai&page=1");
+  await expect(
+    page.getByRole("button", { name: "next16-ai/next16-aidd" }),
+  ).toBeVisible();
+
+  await page.waitForTimeout(200);
+  expect(searchCallCount).toBe(1);
+  expect(repoDetailCallCount).toBe(1);
+});


### PR DESCRIPTION
## 概要
Issue: https://github.com/tomoyuki65/next16-aidd/issues/12
GitHub検索のE2E（検索→詳細→戻る→キャッシュ）を追加

## 背景・目的
検索→一覧→詳細→トップ復帰までの主要導線を、外部API実通信なしで回帰確認できるようにするため。

## 実装内容
- `tests/e2e/mocks/github.ts` に検索/詳細のモックレスポンスを追加
- `tests/e2e/search-flow.spec.ts` で `page.route("https://api.github.com/**")` をモックし、未対応リクエストは `route.abort()` で失敗させる
- `tests/e2e/index.spec.ts` の `page.goto` を baseURL 前提の `"/"` に統一

## テスト確認項目
- [ ] トップで `next16-ai` を検索すると一覧に `next16-ai/next16-aidd` が表示される
- [ ] 一覧から詳細へ遷移し、主要項目（言語・Star/Watcher/Fork/Issue）が表示される
- [ ] ヘッダーの `Next16-AIDD` 押下でトップに戻り、遷移前の一覧が表示されたままになる
- [ ] 未モックの `https://api.github.com/**` リクエストが発生した場合にテストが失敗する

## 影響範囲
- `tests/e2e` のE2Eテストのみ

## 未対応・今後の課題
- なし